### PR TITLE
Character panel overhaul

### DIFF
--- a/CharMaker.tscn
+++ b/CharMaker.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dcq5g3w8sqqsa"]
+[gd_scene load_steps=11 format=3 uid="uid://dcq5g3w8sqqsa"]
 
 [ext_resource type="Script" uid="uid://edtlhuere4x0" path="res://character_info.gd" id="1_ie0yp"]
 [ext_resource type="Texture2D" uid="uid://bc0l8kpimoovl" path="res://char_icons/unknown.png" id="2_nolpt"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://cw4k5166qr806" path="res://ui_icons/folder2.png" id="4_d7fhg"]
 [ext_resource type="Texture2D" uid="uid://cd3t4etm7uoru" path="res://ui_icons/under.png" id="5_rku1n"]
 [ext_resource type="Texture2D" uid="uid://lrn86wakid5s" path="res://ui_icons/over.png" id="6_yvs2x"]
+[ext_resource type="PackedScene" uid="uid://qrmdcea33ubf" path="res://StatSlider.tscn" id="7_65qkp"]
 [ext_resource type="Texture2D" uid="uid://e3ohkiiamuu6" path="res://ui_icons/progress.png" id="7_xn6mw"]
 [ext_resource type="Texture2D" uid="uid://cgjubft8k8u4n" path="res://ui_icons/trashcan.png" id="8_xn6mw"]
 [ext_resource type="Texture2D" uid="uid://c6l82vkbo5dyx" path="res://ui_icons/trashcanOpen.png" id="9_65qkp"]
@@ -18,10 +19,15 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ie0yp")
 
-[node name="MainPanel" type="VBoxContainer" parent="."]
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
 layout_mode = 2
+horizontal_scroll_mode = 0
 
-[node name="CharIcon" type="TextureRect" parent="MainPanel"]
+[node name="MainPanel" type="VBoxContainer" parent="ScrollContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="CharIcon" type="TextureRect" parent="ScrollContainer/MainPanel"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(174, 174)
 layout_mode = 2
@@ -30,7 +36,7 @@ texture = ExtResource("2_nolpt")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="ChangeCharIcon" type="TextureButton" parent="MainPanel/CharIcon"]
+[node name="ChangeCharIcon" type="TextureButton" parent="ScrollContainer/MainPanel/CharIcon"]
 unique_name_in_owner = true
 z_index = 3
 layout_mode = 1
@@ -40,7 +46,7 @@ texture_normal = ExtResource("3_xpj6t")
 texture_pressed = ExtResource("4_d7fhg")
 texture_hover = ExtResource("3_xpj6t")
 
-[node name="FileDialog" type="FileDialog" parent="MainPanel/CharIcon/ChangeCharIcon"]
+[node name="FileDialog" type="FileDialog" parent="ScrollContainer/MainPanel/CharIcon/ChangeCharIcon"]
 unique_name_in_owner = true
 title = "Open a File"
 ok_button_text = "Open"
@@ -48,7 +54,7 @@ file_mode = 0
 access = 2
 filters = PackedStringArray("*.jpg", "*png", "*jpeg")
 
-[node name="DeleteButton" type="TextureButton" parent="MainPanel/CharIcon"]
+[node name="DeleteButton" type="TextureButton" parent="ScrollContainer/MainPanel/CharIcon"]
 unique_name_in_owner = true
 z_index = 3
 layout_mode = 1
@@ -65,55 +71,25 @@ texture_normal = ExtResource("8_xn6mw")
 texture_pressed = ExtResource("9_65qkp")
 texture_hover = ExtResource("9_65qkp")
 
-[node name="ConfirmationDialog" type="ConfirmationDialog" parent="MainPanel/CharIcon/DeleteButton"]
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="ScrollContainer/MainPanel/CharIcon/DeleteButton"]
 unique_name_in_owner = true
 initial_position = 2
 size = Vector2i(270, 100)
 ok_button_text = "Delete"
 dialog_text = "Are you sure you want to delete?"
 
-[node name="NameLabel" type="RichTextLabel" parent="MainPanel"]
+[node name="NameLabel" type="RichTextLabel" parent="ScrollContainer/MainPanel"]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 bbcode_enabled = true
 
-[node name="EditControls" type="VBoxContainer" parent="MainPanel"]
+[node name="Bars" type="VBoxContainer" parent="ScrollContainer/MainPanel"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="NameInput" type="LineEdit" parent="MainPanel/EditControls"]
-unique_name_in_owner = true
-layout_mode = 2
-placeholder_text = "Character Name"
-alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="PronounsButton" type="OptionButton" parent="MainPanel/EditControls"]
-unique_name_in_owner = true
-layout_mode = 2
-alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="PersonalityButton" type="OptionButton" parent="MainPanel/EditControls"]
-unique_name_in_owner = true
-layout_mode = 2
-alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="BuildsButton" type="OptionButton" parent="MainPanel/EditControls"]
-unique_name_in_owner = true
-layout_mode = 2
-alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="Bars" type="VBoxContainer" parent="MainPanel"]
-unique_name_in_owner = true
-visible = false
-layout_mode = 2
-
-[node name="HealthBar" type="TextureProgressBar" parent="MainPanel/Bars"]
+[node name="HealthBar" type="TextureProgressBar" parent="ScrollContainer/MainPanel/Bars"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -126,7 +102,7 @@ texture_under = ExtResource("5_rku1n")
 texture_over = ExtResource("6_yvs2x")
 texture_progress = ExtResource("7_xn6mw")
 
-[node name="Health" type="RichTextLabel" parent="MainPanel/Bars/HealthBar"]
+[node name="Health" type="RichTextLabel" parent="ScrollContainer/MainPanel/Bars/HealthBar"]
 unique_name_in_owner = true
 z_index = 1
 layout_mode = 1
@@ -138,7 +114,7 @@ grow_vertical = 2
 bbcode_enabled = true
 text = "[center]HP: ???/???[/center]"
 
-[node name="SanityBar" type="TextureProgressBar" parent="MainPanel/Bars"]
+[node name="SanityBar" type="TextureProgressBar" parent="ScrollContainer/MainPanel/Bars"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -151,7 +127,7 @@ texture_under = ExtResource("5_rku1n")
 texture_over = ExtResource("6_yvs2x")
 texture_progress = ExtResource("7_xn6mw")
 
-[node name="Sanity" type="RichTextLabel" parent="MainPanel/Bars/SanityBar"]
+[node name="Sanity" type="RichTextLabel" parent="ScrollContainer/MainPanel/Bars/SanityBar"]
 unique_name_in_owner = true
 z_index = 1
 layout_mode = 1
@@ -163,9 +139,56 @@ grow_vertical = 2
 bbcode_enabled = true
 text = "[center]SANITY: ???/???[/center]"
 
-[node name="PosLabel" type="Label" parent="MainPanel"]
+[node name="EditControls" type="VBoxContainer" parent="ScrollContainer/MainPanel"]
 unique_name_in_owner = true
-visible = false
+layout_mode = 2
+
+[node name="NameInput" type="LineEdit" parent="ScrollContainer/MainPanel/EditControls"]
+unique_name_in_owner = true
+layout_mode = 2
+placeholder_text = "Character Name"
+alignment = 1
+metadata/_edit_use_anchors_ = true
+
+[node name="PronounsButton" type="OptionButton" parent="ScrollContainer/MainPanel/EditControls"]
+unique_name_in_owner = true
+layout_mode = 2
+alignment = 1
+metadata/_edit_use_anchors_ = true
+
+[node name="PanelContainer" type="PanelContainer" parent="ScrollContainer/MainPanel/EditControls"]
+layout_mode = 2
+
+[node name="EditStats" type="VBoxContainer" parent="ScrollContainer/MainPanel/EditControls/PanelContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="FormSlider" parent="ScrollContainer/MainPanel/EditControls/PanelContainer/EditStats" instance=ExtResource("7_65qkp")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="EnduranceSlider" parent="ScrollContainer/MainPanel/EditControls/PanelContainer/EditStats" instance=ExtResource("7_65qkp")]
+unique_name_in_owner = true
+layout_mode = 2
+modified_stat = "endurance"
+
+[node name="PerceptionSlider" parent="ScrollContainer/MainPanel/EditControls/PanelContainer/EditStats" instance=ExtResource("7_65qkp")]
+unique_name_in_owner = true
+layout_mode = 2
+modified_stat = "perception"
+
+[node name="IngenuitySlider" parent="ScrollContainer/MainPanel/EditControls/PanelContainer/EditStats" instance=ExtResource("7_65qkp")]
+unique_name_in_owner = true
+layout_mode = 2
+modified_stat = "ingenuity"
+
+[node name="CharismaSlider" parent="ScrollContainer/MainPanel/EditControls/PanelContainer/EditStats" instance=ExtResource("7_65qkp")]
+unique_name_in_owner = true
+layout_mode = 2
+modified_stat = "charisma"
+
+[node name="PosLabel" type="Label" parent="ScrollContainer/MainPanel"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "current pos: ?,?"
 horizontal_alignment = 1

--- a/Main.tscn
+++ b/Main.tscn
@@ -67,6 +67,7 @@ vertical_scroll_mode = 0
 [node name="Characters" type="HBoxContainer" parent="Characters"]
 layout_mode = 2
 size_flags_horizontal = 6
+size_flags_vertical = 3
 alignment = 1
 
 [node name="Character" parent="Characters/Characters" instance=ExtResource("3_20pc6")]

--- a/StatSlider.tscn
+++ b/StatSlider.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=2 format=3 uid="uid://qrmdcea33ubf"]
+
+[ext_resource type="Script" uid="uid://cmy7ua81esdon" path="res://stat_slider.gd" id="1_182am"]
+
+[node name="StatSlider" type="HBoxContainer"]
+offset_right = 142.0
+offset_bottom = 23.0
+script = ExtResource("1_182am")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+custom_minimum_size = Vector2(110, 0)
+layout_mode = 2
+
+[node name="LabelStat" type="Label" parent="MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "form"
+vertical_alignment = 1
+
+[node name="LabelNum" type="Label" parent="MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "1"
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="Slider" type="HSlider" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+min_value = 1.0
+max_value = 5.0
+value = 1.0
+rounded = true
+tick_count = 5
+ticks_on_borders = true

--- a/character_info.gd
+++ b/character_info.gd
@@ -22,21 +22,6 @@ var available_pronouns = {"he/him": {"subj": "he", "obj": "him", "poss": "his", 
 var picked_pronoun_key: String = "they/them"
 var pronouns: Dictionary = available_pronouns[picked_pronoun_key]
 
-var builds = {
-	"Overweight": {"form_mod": 1, "end_mod": 2, "ing_mod": 1},
-	"Average": {"form_mod": 2, "end_mod": 2, "ing_mod": 1},
-	"Underweight": {"form_mod": 2, "end_mod": 1, "ing_mod": 1},
-	"Muscular": {"form_mod": 3, "end_mod": 3, "ing_mod": 1}
-	}
-
-var personalities = {
-	"Bubbly": {"percep_mod": 1, "chr_mod": 3, "ing_mod": 1},
-	"Reserved": {"percep_mod": 1, "chr_mod": 2, "ing_mod": 1},
-	"Keen": {"percep_mod": 3, "chr_mod": 1, "ing_mod": 1},
-	"Dull": {"percep_mod": 2, "chr_mod": 1, "ing_mod": 1},
-	"Chill": {"percep_mod": 2, "chr_mod": 2, "ing_mod": 1},
-	}
-	
 # Core Stats
 var form: int = 1
 var endurance: int = 1
@@ -58,8 +43,6 @@ var inventory: Array = [] # For items later
 
 @onready var name_input: LineEdit = %NameInput
 @onready var pronouns_button: OptionButton = %PronounsButton
-@onready var personality_button: OptionButton = %PersonalityButton
-@onready var builds_button: OptionButton = %BuildsButton
 @onready var name_label: RichTextLabel = %NameLabel
 @onready var health_label: RichTextLabel = %Health
 @onready var sanity_label: RichTextLabel = %Sanity
@@ -73,6 +56,14 @@ var inventory: Array = [] # For items later
 @onready var edit_controls = %EditControls
 @onready var bars = %Bars
 @onready var pos_label = %PosLabel
+
+#stats
+@onready var form_slider = %FormSlider
+@onready var endurance_slider = %EnduranceSlider
+@onready var perception_slider = %PerceptionSlider
+@onready var ingenuity_slider = %IngenuitySlider
+@onready var charisma_slider = %CharismaSlider
+#/stats
 
 @onready var MainGameController = get_tree().get_first_node_in_group("GameControllers")
 
@@ -112,15 +103,14 @@ func _ready() -> void:
 		else:
 			printerr("Pronoun OptionButton has no items!")
 
-	for personality in personalities:
-		personality_button.add_item(personality)
-
-	for build in builds:
-		builds_button.add_item(build)
-
 	pronouns_button.item_selected.connect(_on_pronoun_selected)
-	personality_button.item_selected.connect(on_selection_changed)
-	builds_button.item_selected.connect(on_selection_changed)
+	# stats
+	form_slider.value_changed.connect(on_value_changed)
+	endurance_slider.value_changed.connect(on_value_changed)
+	perception_slider.value_changed.connect(on_value_changed)
+	ingenuity_slider.value_changed.connect(on_value_changed)
+	charisma_slider.value_changed.connect(on_value_changed)
+	# /stats
 	name_input.text_changed.connect(_on_name_input_text_changed)
 	change_img.pressed.connect(_on_change_char_icon_pressed)
 	delete_char.pressed.connect(_on_delete_button_pressed)
@@ -168,27 +158,11 @@ func set_sanity(value: int):
 
 
 func calculate_stats():
-	form = 1
-	endurance = 1
-	perception = 1
-	ingenuity = 1
-	charisma = 1
-
-	# Apply mods from selected build
-	var selected_build = builds_button.get_item_text(builds_button.selected)
-	if builds.has(selected_build):
-		var build_mods = builds[selected_build]
-		form += build_mods["form_mod"]
-		endurance += build_mods["end_mod"]
-		ingenuity += build_mods["ing_mod"]
-
-	# Apply mods from selected personality
-	var selected_personality = personality_button.get_item_text(personality_button.selected)
-	if personalities.has(selected_personality):
-		var personality_mods = personalities[selected_personality]
-		perception += personality_mods["percep_mod"]
-		ingenuity += personality_mods["ing_mod"]
-		charisma += personality_mods["chr_mod"]
+	form = form_slider.stat_value
+	endurance = endurance_slider.stat_value
+	perception = perception_slider.stat_value
+	ingenuity = ingenuity_slider.stat_value
+	charisma = charisma_slider.stat_value
 
 	# Calculate derived stats. All formulas are subject to change.
 	max_health = 5 + (form * 5) + (endurance * 2) + ingenuity
@@ -205,7 +179,6 @@ func calculate_stats():
 	if sanity == max_sanity or sanity > max_sanity:
 		set_sanity(max_sanity) # Use setter
 
-	update_ui_labels()
 	stats_finalized.emit(self) # Notify parent potentially
 
 func update_ui_labels():
@@ -270,7 +243,7 @@ func _on_pronoun_selected(index: int) -> void:
 		pronouns = available_pronouns[picked_pronoun_key]
 
 
-func on_selection_changed(index: int) -> void:
+func on_value_changed(_value: int) -> void:
 	calculate_stats()
 
 func _on_change_char_icon_pressed() -> void:
@@ -289,9 +262,7 @@ func toggle_ui(toggle):
 	edit_controls.visible = not toggle
 	change_img.visible = not toggle
 	delete_char.visible = not toggle
-	bars.visible = toggle
 	name_label.visible = toggle
-	pos_label.visible = toggle
 
 
 func _on_delete_button_pressed() -> void:

--- a/stat_slider.gd
+++ b/stat_slider.gd
@@ -1,0 +1,43 @@
+@tool
+extends HBoxContainer
+
+signal value_changed(value: int)
+
+@export_enum("form", "endurance", "perception", "ingenuity", "charisma") var modified_stat: String = "form":
+	get:
+		return modified_stat
+	set(value):
+		modified_stat = value
+		update_label()
+
+@export_range(1, 5, 1) var stat_value: int = 1:
+	get:
+		return stat_value
+	set(value):
+		stat_value = value
+		slider.set_value_no_signal(float(stat_value))
+		update_label()
+		value_changed.emit(stat_value)
+
+var label_stat: Label
+var label_num: Label
+var slider: Slider
+
+func _ready():
+	label_stat = get_node("%LabelStat")
+	label_num = get_node("%LabelNum")
+	slider = get_node("%Slider")
+	update_label()
+	slider.value_changed.connect(_on_value_changed)
+
+
+func _on_value_changed(value: int):
+	stat_value = int(value)
+	update_label()
+
+
+func update_label():
+	if label_stat:
+		label_stat.text = modified_stat
+	if label_num:
+		label_num.text = str(stat_value)

--- a/stat_slider.gd.uid
+++ b/stat_slider.gd.uid
@@ -1,0 +1,1 @@
+uid://cmy7ua81esdon


### PR DESCRIPTION
Remove personality and builds presets, and give the ability to change each stat individually
Reflect the changes on health/sanity immediately
Show bars and pos even during editing
Create a flexible and reusable "stat slider" ui element
Make character panel expand vertically