### PR TITLE
Make relationship editor its own popup window

### DIFF
--- a/CastMaker.tscn
+++ b/CastMaker.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://c62mvng83jemu"]
+[gd_scene load_steps=15 format=3 uid="uid://c62mvng83jemu"]
 
 [ext_resource type="Script" uid="uid://dsq7mbcr56orw" path="res://cast_maker.gd" id="1_2hpj6"]
 [ext_resource type="Script" uid="uid://5yrxr8v5bvv5" path="res://add_char_button.gd" id="2_jr0kw"]
@@ -7,11 +7,17 @@
 [ext_resource type="Script" uid="uid://dekq6aob67m30" path="res://rand_icons.gd" id="3_jr0kw"]
 [ext_resource type="Script" uid="uid://bxmk1kywhut43" path="res://bulk_add_characters.gd" id="3_x7ypp"]
 [ext_resource type="Texture2D" uid="uid://bs6gyyfnjn112" path="res://ui_icons/KFR.png" id="4_2i1q7"]
+[ext_resource type="Script" uid="uid://n7clvw6aqpsm" path="res://bulk_slider.gd" id="4_f17vn"]
 [ext_resource type="Script" uid="uid://cf2dlr2t1jbqi" path="res://rand_stats.gd" id="4_k0cod"]
 [ext_resource type="Script" uid="uid://dn8q0x0dk133l" path="res://clear_cast.gd" id="4_pga40"]
 [ext_resource type="Script" uid="uid://rkbyl8nynyr7" path="res://rand_names.gd" id="5_q18fw"]
 [ext_resource type="Script" uid="uid://c41ativ1qnk7q" path="res://rand_all.gd" id="6_eb18u"]
 [ext_resource type="AudioStream" uid="uid://dplrjswfsr1a" path="res://castbuilder.mp3" id="7_avln1"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_2hpj6"]
+font_color = Color(1, 1, 1, 0.666667)
+outline_size = 8
+outline_color = Color(0, 0, 0, 0.670588)
 
 [node name="CastMaker" type="Control"]
 layout_mode = 3
@@ -35,8 +41,9 @@ layout_mode = 2
 
 [node name="CharacterContainer" type="HFlowContainer" parent="PanelContainer/ScrollContainer" groups=["CastMaker"]]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(1061.48, 0)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("2_jr0kw")
 
 [node name="PanelContainer2" type="PanelContainer" parent="."]
@@ -67,11 +74,25 @@ text = "Add Character"
 [node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer2/VBoxContainer"]
 layout_mode = 2
 
-[node name="BulkLabel" type="TextEdit" parent="PanelContainer2/VBoxContainer/HBoxContainer"]
+[node name="BulkSlider" type="HSlider" parent="PanelContainer2/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(127.8, 43.345)
 layout_mode = 2
-placeholder_text = "Type # Here"
+size_flags_horizontal = 3
+size_flags_vertical = 1
+min_value = 1.0
+value = 1.0
+script = ExtResource("4_f17vn")
+
+[node name="Label" type="Label" parent="PanelContainer2/VBoxContainer/HBoxContainer/BulkSlider"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "1"
+label_settings = SubResource("LabelSettings_2hpj6")
+horizontal_alignment = 1
 
 [node name="Bulk Add Characters" type="Button" parent="PanelContainer2/VBoxContainer/HBoxContainer"]
 layout_mode = 2
@@ -79,6 +100,7 @@ text = "Bulk Add Characters"
 script = ExtResource("3_x7ypp")
 
 [node name="CharacterCounter" type="Label" parent="PanelContainer2/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Current Characters: 0"
 horizontal_alignment = 1
@@ -129,6 +151,53 @@ size_flags_vertical = 8
 text = "Randomize All"
 script = ExtResource("6_eb18u")
 
+[node name="BlockInputRect" type="ColorRect" parent="."]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(1, 1, 1, 0.156863)
+
+[node name="CenterContainer" type="CenterContainer" parent="BlockInputRect"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="BlockInputRect/CenterContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="BlockInputRect/CenterContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 32
+theme_override_constants/margin_top = 32
+theme_override_constants/margin_right = 32
+theme_override_constants/margin_bottom = 32
+
+[node name="VBoxContainer" type="VBoxContainer" parent="BlockInputRect/CenterContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="BlockInputLabel" type="RichTextLabel" parent="BlockInputRect/CenterContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/outline_size = 8
+text = "Adding Characters..."
+fit_content = true
+autowrap_mode = 0
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="BlockInterruptButton" type="Button" parent="BlockInputRect/CenterContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Interrupt"
+
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("7_avln1")
 autoplay = true
@@ -136,6 +205,7 @@ autoplay = true
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/Start Game" to="PanelContainer2/VBoxContainer/Start Game" method="_on_pressed"]
 [connection signal="confirmed" from="PanelContainer2/VBoxContainer/Start Game/StartGameDialog" to="." method="_on_start_game_dialog_confirmed"]
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/Add Character" to="PanelContainer/ScrollContainer/CharacterContainer" method="_on_add_character_pressed"]
+[connection signal="value_changed" from="PanelContainer2/VBoxContainer/HBoxContainer/BulkSlider" to="PanelContainer2/VBoxContainer/HBoxContainer/BulkSlider" method="_on_value_changed"]
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/HBoxContainer/Bulk Add Characters" to="PanelContainer2/VBoxContainer/HBoxContainer/Bulk Add Characters" method="_on_pressed"]
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/Clear Cast" to="PanelContainer2/VBoxContainer/Clear Cast" method="_on_pressed"]
 [connection signal="confirmed" from="PanelContainer2/VBoxContainer/Clear Cast/AcceptDialog" to="PanelContainer2/VBoxContainer/Clear Cast" method="_on_accept_dialog_confirmed"]
@@ -143,3 +213,4 @@ autoplay = true
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/RandStats" to="PanelContainer2/VBoxContainer/RandStats" method="_on_pressed"]
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/RandNames" to="PanelContainer2/VBoxContainer/RandNames" method="_on_pressed"]
 [connection signal="pressed" from="PanelContainer2/VBoxContainer/RandAll" to="PanelContainer2/VBoxContainer/RandAll" method="_on_pressed"]
+[connection signal="pressed" from="BlockInputRect/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/BlockInterruptButton" to="PanelContainer2/VBoxContainer/HBoxContainer/Bulk Add Characters" method="_on_block_interrupt_button_pressed"]

--- a/FighterCreator.tscn
+++ b/FighterCreator.tscn
@@ -15,10 +15,10 @@
 [ext_resource type="Script" uid="uid://chgrkhxnr7fid" path="res://add_relationship.gd" id="13_agfup"]
 
 [node name="Character" type="PanelContainer"]
+custom_minimum_size = Vector2(520, 270)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -630.94
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_1v8qw")
@@ -30,6 +30,7 @@ horizontal_scroll_mode = 0
 [node name="VBoxContainer2" type="VBoxContainer" parent="ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="MainPanel" type="HBoxContainer" parent="ScrollContainer/VBoxContainer2"]
 layout_mode = 2
@@ -111,7 +112,6 @@ layout_mode = 2
 
 [node name="Bars" type="VBoxContainer" parent="ScrollContainer/VBoxContainer2/MainPanel/VBoxContainer"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="HealthBar" type="TextureProgressBar" parent="ScrollContainer/VBoxContainer2/MainPanel/VBoxContainer/Bars"]
@@ -231,56 +231,48 @@ unique_name_in_owner = true
 layout_mode = 2
 modified_stat = "charisma"
 
-[node name="CastEditorShit" type="HBoxContainer" parent="ScrollContainer/VBoxContainer2"]
-layout_mode = 2
-
-[node name="RelationshipPanel" type="PanelContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit"]
-custom_minimum_size = Vector2(262.325, 149.225)
-layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel"]
-layout_mode = 2
-
-[node name="RelationshipEditorLabel" type="Label" parent="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-text = "Relationship Editor"
-horizontal_alignment = 1
-
-[node name="ScrollContainer" type="ScrollContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer"]
-custom_minimum_size = Vector2(0, 120.63)
-layout_mode = 2
-
-[node name="RelationshipContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer/ScrollContainer"]
+[node name="RelationshipEditor" type="Button" parent="ScrollContainer/VBoxContainer2/MainPanel/EditControls"]
 unique_name_in_owner = true
 layout_mode = 2
-script = ExtResource("12_71vk2")
+text = "Relationship Editor"
 
-[node name="AddRelationship" type="Button" parent="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer/ScrollContainer/RelationshipContainer"]
+[node name="RelationshipWindow" type="AcceptDialog" parent="."]
+unique_name_in_owner = true
+title = "Relationship Editor"
+initial_position = 1
+size = Vector2i(400, 400)
+ok_button_text = "Done"
+
+[node name="RelationshipPanel" type="PanelContainer" parent="RelationshipWindow"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="RelationshipWindow/RelationshipPanel"]
+layout_mode = 2
+
+[node name="AddRelationship" type="Button" parent="RelationshipWindow/RelationshipPanel/VBoxContainer"]
 custom_minimum_size = Vector2(262.095, 0)
 layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 3
+size_flags_vertical = 0
 text = "add relationship"
 script = ExtResource("13_agfup")
 
-[node name="InventoryPanel" type="PanelContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit"]
-custom_minimum_size = Vector2(262.325, 149.225)
+[node name="ScrollContainer" type="ScrollContainer" parent="RelationshipWindow/RelationshipPanel/VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/VBoxContainer2/CastEditorShit/InventoryPanel"]
+[node name="RelationshipContainer" type="VBoxContainer" parent="RelationshipWindow/RelationshipPanel/VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
+script = ExtResource("12_71vk2")
 
-[node name="InventoryEditorLabel" type="Label" parent="ScrollContainer/VBoxContainer2/CastEditorShit/InventoryPanel/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-text = "Inventory Editor"
-horizontal_alignment = 1
-
-[node name="lol" type="Label" parent="ScrollContainer/VBoxContainer2/CastEditorShit/InventoryPanel/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-text = "(there's no inventory yet lol)"
-horizontal_alignment = 1
-
-[connection signal="pressed" from="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer/ScrollContainer/RelationshipContainer/AddRelationship" to="ScrollContainer/VBoxContainer2/CastEditorShit/RelationshipPanel/VBoxContainer/ScrollContainer/RelationshipContainer/AddRelationship" method="_on_pressed"]
+[connection signal="pressed" from="ScrollContainer/VBoxContainer2/MainPanel/EditControls/RelationshipEditor" to="." method="_on_relationship_editor_pressed"]
+[connection signal="pressed" from="RelationshipWindow/RelationshipPanel/VBoxContainer/AddRelationship" to="RelationshipWindow/RelationshipPanel/VBoxContainer/AddRelationship" method="_on_pressed"]

--- a/RelationshipEditor.tscn
+++ b/RelationshipEditor.tscn
@@ -1,26 +1,38 @@
-[gd_scene load_steps=4 format=3 uid="uid://2ek1oh0xlqex"]
+[gd_scene load_steps=6 format=3 uid="uid://2ek1oh0xlqex"]
 
 [ext_resource type="Script" uid="uid://d2q0ansljawiu" path="res://relationship_editor.gd" id="1_hm312"]
 [ext_resource type="Script" uid="uid://jg4ju7wsro17" path="res://relationship_modifier_slider.gd" id="2_hm312"]
 [ext_resource type="Texture2D" uid="uid://ccuf5k0s281ih" path="res://ui_icons/grey_crossWhite.png" id="3_l5xla"]
 
-[node name="RelationshipEditor" type="HBoxContainer"]
-script = ExtResource("1_hm312")
+[sub_resource type="Theme" id="Theme_n2fgw"]
+OptionButton/constants/icon_max_width = 32
+PopupMenu/constants/icon_max_width = 32
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
-custom_minimum_size = Vector2(7.985, 0)
-layout_mode = 2
+[sub_resource type="LabelSettings" id="LabelSettings_2hpj6"]
+font_color = Color(1, 1, 1, 0.666667)
+outline_size = 8
+outline_color = Color(0, 0, 0, 0.670588)
+
+[node name="RelationshipEditor" type="HBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+theme = SubResource("Theme_n2fgw")
+script = ExtResource("1_hm312")
 
 [node name="RelationshipOptions" type="OptionButton" parent="."]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(72.61, 0)
+custom_minimum_size = Vector2(216, 40)
 layout_mode = 2
-text_overrun_behavior = 1
+selected = 0
 item_count = 1
-popup/item_0/text = "[None]"
 popup/item_0/id = 0
 
-[node name="HSlider" type="HSlider" parent="."]
+[node name="RelationshipSlider" type="HSlider" parent="."]
 custom_minimum_size = Vector2(80.545, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -28,15 +40,30 @@ size_flags_vertical = 1
 min_value = -10.0
 max_value = 10.0
 
-[node name="RelationshipModifierSlider" type="Label" parent="."]
-layout_mode = 2
+[node name="RelationshipModifierSlider" type="Label" parent="RelationshipSlider"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "0"
+label_settings = SubResource("LabelSettings_2hpj6")
+horizontal_alignment = 1
+vertical_alignment = 1
 script = ExtResource("2_hm312")
 
-[node name="delete" type="TextureButton" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_right = 16
+
+[node name="delete" type="TextureButton" parent="MarginContainer"]
 layout_mode = 2
 texture_normal = ExtResource("3_l5xla")
+stretch_mode = 3
 
 [connection signal="item_selected" from="RelationshipOptions" to="." method="_on_relationship_options_item_selected"]
 [connection signal="pressed" from="RelationshipOptions" to="." method="_on_relationship_options_pressed"]
-[connection signal="pressed" from="delete" to="." method="_on_delete_pressed"]
+[connection signal="value_changed" from="RelationshipSlider" to="RelationshipSlider/RelationshipModifierSlider" method="_on_relationship_slider_value_changed"]
+[connection signal="pressed" from="MarginContainer/delete" to="." method="_on_delete_pressed"]

--- a/add_char_button.gd
+++ b/add_char_button.gd
@@ -4,9 +4,6 @@ extends HFlowContainer
 
 func _on_add_character_pressed() -> void:
 	var character = new_char.instantiate()
-	character.custom_minimum_size = Vector2(0, 356.425) 
 	add_child(character)
 	Cast.current_cast = get_children()
-	print(Cast.current_cast)
 
-	

--- a/add_relationship.gd
+++ b/add_relationship.gd
@@ -4,5 +4,4 @@ var relationship_scene = preload("res://RelationshipEditor.tscn")
 
 func _on_pressed() -> void:
 	var new_relationship = relationship_scene.instantiate()
-	add_sibling(new_relationship)
-	pass # Replace with function body.
+	%RelationshipContainer.add_child(new_relationship)

--- a/bulk_add_characters.gd
+++ b/bulk_add_characters.gd
@@ -2,19 +2,32 @@ extends Button
 
 @onready var new_char = preload("res://FighterCreator.tscn")
 
+var interrupt = false
+
 func _on_add_character_pressed() -> void:
 	var character = new_char.instantiate()
-	character.custom_minimum_size = Vector2(0, 356.425) 
 	add_child(character)
 	Cast.current_cast = get_children()
 
 
 func _on_pressed() -> void:
-	var times_to_add = int(%BulkLabel.text)
-
+	var times_to_add = int(%BulkSlider.value)
+	get_viewport().gui_release_focus()
+	%BlockInputRect.show()
+	interrupt = false
+	var chars_added = 0
 	for num in range(0, times_to_add):
+		if interrupt:
+			break
 		var character = new_char.instantiate()
-		character.custom_minimum_size = Vector2(0, 356.425) 
 		%CharacterContainer.add_child(character)
 		Cast.current_cast = %CharacterContainer.get_children()
-	
+		chars_added += 1
+		%BlockInputLabel.text = "Adding characters...\n%s left" % [times_to_add - chars_added]
+		if chars_added % 2 == 0:
+			await get_tree().process_frame
+	%BlockInputRect.hide()
+
+
+func _on_block_interrupt_button_pressed() -> void:
+	interrupt = true

--- a/bulk_slider.gd
+++ b/bulk_slider.gd
@@ -1,0 +1,5 @@
+extends HSlider
+
+
+func _on_value_changed(_value:float) -> void:
+	$Label.text = str(int(_value))

--- a/bulk_slider.gd.uid
+++ b/bulk_slider.gd.uid
@@ -1,0 +1,1 @@
+uid://n7clvw6aqpsm

--- a/cast.gd
+++ b/cast.gd
@@ -1,8 +1,17 @@
 extends Node
 
-var current_cast: Array = []
+signal changed
 
-var picked_relationship: Array = []
+var current_cast: Array = []:
+	set(value):
+		current_cast = value
+		changed.emit()
 
-func _ready() -> void:
-	pass
+func add_character(chara: Character):
+	var chara_dict = {}
+	chara_dict["name"] = chara.char_name
+	chara_dict["form"] = chara.form
+	chara_dict["endurance"] = chara.endurance
+	chara_dict["perception"] = chara.perception
+	chara_dict["ingenuity"] = chara.ingenuity
+	chara_dict["charisma"] = chara.charisma

--- a/character_info.gd
+++ b/character_info.gd
@@ -62,6 +62,8 @@ var inventory: Array = [] # For items later
 
 @onready var editstats = %EditStats
 
+@onready var relationship_window = %RelationshipWindow
+
 #stats
 @onready var form_slider = %FormSlider
 @onready var endurance_slider = %EnduranceSlider
@@ -136,14 +138,14 @@ func move(move_x, move_y):
 		print(char_name + " cannot move because they're dead, lol.")
 	
 func set_char_name(new_name: String):
-	print("set_char_name: Received:", new_name) 
 	var potential_name = new_name.strip_edges() 
 	if potential_name.is_empty():
 		potential_name = "Tribute" # Default if empty
 
 	if char_name != potential_name:
 		char_name = potential_name
-		print("set_char_name: char_name is now:", char_name)
+
+	name_label.text = "[center][font_size=22]" + char_name + "[/font_size][/center]"
 
 func set_health(value: int):
 	var previous_health = health
@@ -226,15 +228,7 @@ func remove_item(item_name: String):
 
 # --- Signal Callbacks ---
 func _on_name_input_text_changed(new_text) -> void:
-	print("_on_name_input_text_changed: Input text is now:", new_text)
-	var current_input_text = new_text.strip_edges()
-	if current_input_text.is_empty():
-		char_name = "Tribute"
-	else:
-		char_name = current_input_text
-	print("_on_name_input_text_changed: char_name updated to:", char_name)
-	
-	name_label.text = "[center][font_size=22]" + new_text + "[/font_size][/center]"
+	set_char_name(new_text)
 	
 func _on_pronoun_selected(index: int) -> void:
 	picked_pronoun_key = pronouns_button.get_item_text(index)
@@ -277,3 +271,8 @@ func _on_delete_button_pressed() -> void:
 func confirm_delete() -> void:
 	Cast.current_cast.erase(self)
 	queue_free()
+
+
+func _on_relationship_editor_pressed() -> void:
+	relationship_window.popup()
+	relationship_window.title = "Relationships for " + char_name

--- a/clear_cast.gd
+++ b/clear_cast.gd
@@ -5,4 +5,5 @@ func _on_pressed() -> void:
 
 func _on_accept_dialog_confirmed() -> void:
 	for child in %CharacterContainer.get_children():
+		Cast.current_cast.erase(child)
 		child.queue_free()

--- a/current_characters_label.gd
+++ b/current_characters_label.gd
@@ -1,4 +1,4 @@
 extends Label
 
-func _physics_process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	text = "Current Characters: " + str(int(Cast.current_cast.size()))

--- a/rand_names.gd
+++ b/rand_names.gd
@@ -17,12 +17,12 @@ func randomize_names():
 	for char in %CharacterContainer.get_children():
 		if not picked_names.has(picked_name):
 			picked_name = names.pick_random()
-			char.name_input.text = picked_name
 			picked_names.append(picked_name)
 		else:
 			names.shuffle()
 			picked_name = names.pick_random()
-			char.name_input.text = picked_name
+		char.name_input.text = picked_name
+		char.name_input.text_changed.emit(picked_name)
 
 
 func _on_pressed() -> void:

--- a/relationship_editor.gd
+++ b/relationship_editor.gd
@@ -1,40 +1,20 @@
 extends HBoxContainer
-@onready var r_options = %RelationshipOptions
+@onready var r_options: OptionButton = %RelationshipOptions
 var in_list: Array = []
 var current_edited: Array = []
 
-func resize_texture(texture: Texture2D, new_size: Vector2) -> Texture2D:
-	var img := texture.get_image()
-	img.resize(new_size.x, new_size.y, Image.INTERPOLATE_LANCZOS)
-	var resized_texture = ImageTexture.create_from_image(img)
-	return resized_texture
-
 func _on_relationship_options_pressed() -> void:
-	
-
+	var old_selected = r_options.selected
 	r_options.clear()
 	in_list.clear()
 
-	for char in Cast.current_cast:		
-		if char in Cast.picked_relationship:
-			continue
-		var char_icon = char.texture_rect.texture
-		var char_name = char.name_input.text
-		var resized_icon = resize_texture(char.texture_rect.texture, Vector2(32, 32)) 
-		r_options.add_icon_item(resized_icon, char_name)
+	for chara in Cast.current_cast:
+		var char_icon = chara.texture_rect.texture
+		var char_name = chara.name_input.text
+		r_options.add_icon_item(char_icon, char_name)
 		
-		in_list.append(char)
-	pass # Replace with function body.
-	
+		in_list.append(chara)
+	r_options.selected = old_selected
 
 func _on_delete_pressed() -> void:
 	queue_free()
-	pass # Replace with function body.
-
-
-func _on_relationship_options_item_selected(index: int) -> void:
-	if Cast.current_cast.get(index) in Cast.picked_relationship:
-		Cast.picked_relationship.remove_at(index)
-	else:
-		print(index, " was selected.")
-		Cast.picked_relationship.append(Cast.current_cast.get(index))

--- a/relationship_modifier_slider.gd
+++ b/relationship_modifier_slider.gd
@@ -1,4 +1,4 @@
 extends Label
 
-func _physics_process(delta: float) -> void:
-	set_text(str(int($"../HSlider".value)))
+func _on_relationship_slider_value_changed(value: float) -> void:
+	set_text(str(int(value)))


### PR DESCRIPTION
Make rand_names emit text_changed so anything listening to that signal gets updated too
Improve fighter creator scene
Use _process, not _physics_process
Add a "changed" signal when current_cast is set to something
Use slider for bulk adding chars
Fix lag when adding a lot of characters, delaying the panel creation by a bit


PARADOX DON'T FORGET!!!!!!!!!!!!!!!
Cast.gd should have functions for modifying the cast list that should be called everywhere, in addition, you should store all the relevant character properties in the dictionary.

The character UI scene can then reference that dictionary for the stats rather than duplicating code all over the place. HOPE I MADE MYSELF CLEAR!!! :)