### PR TITLE
Treat "participants" as minimum number needed for event

### DIFF
--- a/EventHandler.gd
+++ b/EventHandler.gd
@@ -103,7 +103,7 @@ func trigger_random_event():
 
 		var suitable_events = []
 		for event_dict in event_data:
-			if event_dict.has("participants") and event_dict["participants"] is float and event_dict.get("participants", -1) == group_size:
+			if event_dict.has("participants") and event_dict["participants"] is float and event_dict.get("participants", -1) <= group_size:
 				suitable_events.append(event_dict)
 
 		if not suitable_events.is_empty():

--- a/Main.tscn
+++ b/Main.tscn
@@ -19,8 +19,6 @@ script = ExtResource("1_cm0pq")
 
 [node name="MainGame" type="Node" parent="." groups=["GameControllers"]]
 script = ExtResource("1_03owx")
-map_size_maximum_y = 1
-map_size_maximum_x = 1
 
 [node name="EventHandler" type="Node" parent="." groups=["GameControllers"]]
 unique_name_in_owner = true

--- a/Sim_Loader.gd
+++ b/Sim_Loader.gd
@@ -3,6 +3,7 @@ extends Node2D
 var save_file_path = "user://save/"
 var save_file_name = "Temp.Tres"
 var cast = CastData.new()
+@onready var MainGameController = get_tree().get_first_node_in_group("GameControllers")
 
 func _ready():
 	for char in %Characters.get_children():
@@ -24,6 +25,8 @@ func _ready():
 		instance.perception_slider._on_value_changed(char["perception"])
 		instance.ingenuity_slider._on_value_changed(char["ingenuity"])
 		instance.charisma_slider._on_value_changed(char["charisma"])
+		instance.pos.x = randi_range(0, MainGameController.map_size_maximum_x)
+		instance.pos.y = randi_range(0, MainGameController.map_size_maximum_y)
 		
 	
 func loadcast():


### PR DESCRIPTION
Allow events to happen even if area has more participants than necessary (treat "participants" as minimum number required than _exact_ number required)